### PR TITLE
Switch attitude multiple-shooting from quaternions to SO(3) Lie algebra coordinates

### DIFF
--- a/spacecraft_libraries/dynamics.py
+++ b/spacecraft_libraries/dynamics.py
@@ -202,6 +202,61 @@ def skew_casadi(vector):
         ca.horzcat(-vector[1], vector[0], 0)
     )
 
+def hat_casadi(v):
+    """hat map: R^3 -> so(3)."""
+    return skew_casadi(v)
+
+def vee_casadi(S):
+    """vee map: so(3) -> R^3."""
+    return ca.vertcat(S[2, 1], S[0, 2], S[1, 0])
+
+def so3_exp_casadi(phi):
+    """SO(3) exponential map using Rodrigues' formula with small-angle handling."""
+    theta = ca.norm_2(phi)
+    Phi = hat_casadi(phi)
+    I3 = ca.SX.eye(3)
+
+    theta2 = theta * theta
+    theta4 = theta2 * theta2
+
+    A_small = 1 - theta2 / 6 + theta4 / 120
+    B_small = 0.5 - theta2 / 24 + theta4 / 720
+
+    A = ca.if_else(theta < 1e-6, A_small, ca.sin(theta) / theta)
+    B = ca.if_else(theta < 1e-6, B_small, (1 - ca.cos(theta)) / theta2)
+
+    return I3 + A * Phi + B * (Phi @ Phi)
+
+def so3_log_casadi(R):
+    """SO(3) logarithm map with small-angle approximation and acos clamping."""
+    tr = R[0, 0] + R[1, 1] + R[2, 2]
+    cos_theta = ca.fmin(ca.fmax((tr - 1) / 2, -1 + 1e-9), 1 - 1e-9)
+    theta = ca.acos(cos_theta)
+
+    skew_part = 0.5 * (R - R.T)
+    v_small = vee_casadi(skew_part)
+
+    sin_theta = ca.sin(theta)
+    scale = ca.if_else(ca.fabs(sin_theta) < 1e-6, 1.0, theta / sin_theta)
+    return ca.if_else(theta < 1e-6, v_small, scale * v_small)
+
+def rotational_step_casadi(state, tau, dt, I):
+    """Rigid-body rotation step on SO(3): state = [phi, omega]."""
+    phi = state[0:3]
+    omega = state[3:6]
+
+    # Torque affects angular velocity through Euler's rigid body dynamics.
+    omega_dot = ca.solve(I, tau - ca.cross(omega, I @ omega))
+    omega_next = omega + dt * omega_dot
+
+    # Lie-group attitude propagation replacing quaternion Euler + normalization.
+    R_k = so3_exp_casadi(phi)
+    R_increment = so3_exp_casadi(dt * omega)
+    R_next = R_k @ R_increment
+    phi_next = so3_log_casadi(R_next)
+
+    return ca.vertcat(phi_next, omega_next)
+
 def quat_mult_casadi(q1, q2):
     """Quaternion multiplication using CasADi."""
     w1, x1, y1, z1 = q1[0], q1[1], q1[2], q1[3]
@@ -251,17 +306,14 @@ def Phi_casadi(o, I):
 
 # Define the state derivative function using CasADi
 def rotational_derivative_casadi(state, tau, I):
-    quat = state[0:4]
-    omega = state[4:7]
+    """Rigid-body rotational derivative for state = [phi, omega]."""
+    omega = state[3:6]
 
-    # Quaternion derivative using quaternion multiplication
-    omega_quat = ca.vertcat(0, omega[0], omega[1], omega[2])
-    quat_dot = 0.5 * quat_mult_casadi(quat, omega_quat)
-
-    # Angular velocity derivative
+    # Fallback local-coordinate derivative (used only if caller integrates explicitly).
+    phi_dot = omega
     omega_dot = ca.solve(I, tau - ca.cross(omega, I @ omega))
 
-    return ca.vertcat(quat_dot, omega_dot)
+    return ca.vertcat(phi_dot, omega_dot)
 
 def smooth_norm(vec, delta):
     return ca.sqrt(ca.dot(vec, vec) + delta**2)

--- a/spacecraft_libraries/genetic_code.py
+++ b/spacecraft_libraries/genetic_code.py
@@ -5,11 +5,33 @@ import sys
 import os
 from .new_opts import tau_proj_nonlin_new, opt_given_tau_ipopt_new, opt_given_tau_cvx_new
 
+
+def _quaternion_to_phi(q):
+    """Convert quaternion [w, x, y, z] to so(3) rotation vector phi."""
+    q = np.asarray(q).flatten()
+    if q.size == 3:
+        return q
+    if q.size != 4:
+        raise ValueError("Expected boundary attitude as phi(3) or quaternion(4).")
+
+    q = q / np.linalg.norm(q)
+    w = np.clip(q[0], -1.0, 1.0)
+    v = q[1:]
+    v_norm = np.linalg.norm(v)
+
+    if v_norm < 1e-12:
+        return np.zeros(3)
+
+    angle = 2.0 * np.arctan2(v_norm, w)
+    axis = v / v_norm
+    return angle * axis
+
+
 #og version
-def multiple_shooting_optimization(a0, af, num_steps, dt_casadi, I_casadi, epsilon_casadi, num_iter=None):
+def multiple_shooting_optimization(a0, af, num_steps, dt_casadi, I_casadi, epsilon_casadi=None, num_iter=None):
     # Define CasADi variables for control inputs and states
     tau = [ca.SX.sym(f'tau_{k}', 3) for k in range(num_steps)]  # Control torques
-    state = [ca.SX.sym(f'state_{k}', 7) for k in range(num_steps + 1)]  # State (quaternion + angular velocity)
+    state = [ca.SX.sym(f'state_{k}', 6) for k in range(num_steps + 1)]  # State (phi + angular velocity)
     cost = 0
 
     for k in range(num_steps):
@@ -22,30 +44,26 @@ def multiple_shooting_optimization(a0, af, num_steps, dt_casadi, I_casadi, epsil
 
     # Initial state constraint (state[0] == a0)
     constraints.append(state[0] - a0)
-    lbg.extend([0] * 7)
-    ubg.extend([0] * 7)
+    lbg.extend([0] * 6)
+    ubg.extend([0] * 6)
 
     # Dynamics constraints using multiple shooting
     for k in range(num_steps):
         state_k = state[k]
         tau_k = tau[k]
 
-        # Propagate the state to the next step using Euler integration
-        state_k_next = state_k + dt_casadi * rotational_derivative_casadi(state_k, tau_k, I_casadi)
-
-        # Normalize the quaternion using smooth norm
-        quat_next = state_k_next[0:4] / smooth_norm(state_k_next[0:4], epsilon_casadi)
-        state_k_next_normalized = ca.vertcat(quat_next, state_k_next[4:7])
+        # Propagate the state on SO(3) using the exponential map.
+        state_k_next = rotational_step_casadi(state_k, tau_k, dt_casadi, I_casadi)
 
         # Append the dynamics constraint (ensure continuity between intervals)
-        constraints.append(state[k + 1] - state_k_next_normalized)
-        lbg.extend([0] * 7)
-        ubg.extend([0] * 7)
+        constraints.append(state[k + 1] - state_k_next)
+        lbg.extend([0] * 6)
+        ubg.extend([0] * 6)
 
     # Final state constraint (state[num_steps] == af)
     constraints.append(state[num_steps] - af)
-    lbg.extend([0] * 7)
-    ubg.extend([0] * 7)
+    lbg.extend([0] * 6)
+    ubg.extend([0] * 6)
 
     # Set up the optimization problem
     opt_vars = ca.vertcat(*tau, *state)  # Decision variables (controls + states)
@@ -60,8 +78,8 @@ def multiple_shooting_optimization(a0, af, num_steps, dt_casadi, I_casadi, epsil
     tau_upper_bound = ca.inf * np.ones(num_steps * 3)  # Set torque upper bound to 100
 
     ## For state variables, we leave them unbounded
-    state_lower_bound = -ca.inf * np.ones((num_steps + 1) * 7)  # 7 state variables per step
-    state_upper_bound = ca.inf * np.ones((num_steps + 1) * 7)
+    state_lower_bound = -ca.inf * np.ones((num_steps + 1) * 6)  # 6 state variables per step
+    state_upper_bound = ca.inf * np.ones((num_steps + 1) * 6)
 
     # Combine bounds for tau and state variables
     lbx = np.concatenate([tau_lower_bound, state_lower_bound])
@@ -116,17 +134,18 @@ def multiple_shooting_optimization(a0, af, num_steps, dt_casadi, I_casadi, epsil
 
     # Split the solution into tau and state
     tau_opt = w_opt[:num_steps * 3].reshape(num_steps, 3)  # Optimized torques
-    state_opt = w_opt[num_steps * 3:].reshape(num_steps + 1, 7)  # Optimized states
+    state_opt = w_opt[num_steps * 3:].reshape(num_steps + 1, 6)  # Optimized states
 
     return tau_opt, state_opt
 
 #cleaned ver
-def multiple_shooting_optimization_new(bc: BoundaryConditions, num_steps, dt_casadi, I_casadi, epsilon_casadi, num_iter=None):
-    a0 = np.hstack((bc.x0.eps, bc.x0.omega))
-    af = np.hstack((bc.xf.eps, bc.xf.omega))
+def multiple_shooting_optimization_new(bc: BoundaryConditions, num_steps, dt_casadi, I_casadi, epsilon_casadi=None, num_iter=None):
+    # Boundary angular state is now [phi, omega] in R^6.
+    a0 = np.hstack((_quaternion_to_phi(bc.x0.eps), bc.x0.omega))
+    af = np.hstack((_quaternion_to_phi(bc.xf.eps), bc.xf.omega))
     # Define CasADi variables for control inputs and states
     tau = [ca.SX.sym(f'tau_{k}', 3) for k in range(num_steps)]  # Control torques
-    state = [ca.SX.sym(f'state_{k}', 7) for k in range(num_steps + 1)]  # State (quaternion + angular velocity)
+    state = [ca.SX.sym(f'state_{k}', 6) for k in range(num_steps + 1)]  # State (phi + angular velocity)
     cost = 0
 
     for k in range(num_steps):
@@ -139,30 +158,26 @@ def multiple_shooting_optimization_new(bc: BoundaryConditions, num_steps, dt_cas
 
     # Initial state constraint (state[0] == a0)
     constraints.append(state[0] - a0)
-    lbg.extend([0] * 7)
-    ubg.extend([0] * 7)
+    lbg.extend([0] * 6)
+    ubg.extend([0] * 6)
 
     # Dynamics constraints using multiple shooting
     for k in range(num_steps):
         state_k = state[k]
         tau_k = tau[k]
 
-        # Propagate the state to the next step using Euler integration
-        state_k_next = state_k + dt_casadi * rotational_derivative_casadi(state_k, tau_k, I_casadi)
-
-        # Normalize the quaternion using smooth norm
-        quat_next = state_k_next[0:4] / smooth_norm(state_k_next[0:4], epsilon_casadi)
-        state_k_next_normalized = ca.vertcat(quat_next, state_k_next[4:7])
+        # Propagate the state on SO(3) using the exponential map.
+        state_k_next = rotational_step_casadi(state_k, tau_k, dt_casadi, I_casadi)
 
         # Append the dynamics constraint (ensure continuity between intervals)
-        constraints.append(state[k + 1] - state_k_next_normalized)
-        lbg.extend([0] * 7)
-        ubg.extend([0] * 7)
+        constraints.append(state[k + 1] - state_k_next)
+        lbg.extend([0] * 6)
+        ubg.extend([0] * 6)
 
     # Final state constraint (state[num_steps] == af)
     constraints.append(state[num_steps] - af)
-    lbg.extend([0] * 7)
-    ubg.extend([0] * 7)
+    lbg.extend([0] * 6)
+    ubg.extend([0] * 6)
 
     # Set up the optimization problem
     opt_vars = ca.vertcat(*tau, *state)  # Decision variables (controls + states)
@@ -177,8 +192,8 @@ def multiple_shooting_optimization_new(bc: BoundaryConditions, num_steps, dt_cas
     tau_upper_bound = ca.inf * np.ones(num_steps * 3)  # Set torque upper bound to 100
 
     ## For state variables, we leave them unbounded
-    state_lower_bound = -ca.inf * np.ones((num_steps + 1) * 7)  # 7 state variables per step
-    state_upper_bound = ca.inf * np.ones((num_steps + 1) * 7)
+    state_lower_bound = -ca.inf * np.ones((num_steps + 1) * 6)  # 6 state variables per step
+    state_upper_bound = ca.inf * np.ones((num_steps + 1) * 6)
 
     # Combine bounds for tau and state variables
     lbx = np.concatenate([tau_lower_bound, state_lower_bound])
@@ -233,7 +248,7 @@ def multiple_shooting_optimization_new(bc: BoundaryConditions, num_steps, dt_cas
 
     # Split the solution into tau and state
     tau_opt = w_opt[:num_steps * 3].reshape(num_steps, 3)  # Optimized torques
-    state_opt = w_opt[num_steps * 3:].reshape(num_steps + 1, 7)  # Optimized states
+    state_opt = w_opt[num_steps * 3:].reshape(num_steps + 1, 6)  # Optimized states
 
     return tau_opt, state_opt
 


### PR DESCRIPTION
## Summary
- Reworked rotational attitude handling in the CasADi multiple-shooting optimizer from a 7D `[quat(4), omega(3)]` state to a 6D `[phi(3), omega(3)]` Lie-algebra state.
- Replaced quaternion Euler-step + post-step normalization with geometric SO(3) propagation:
  - `R_k = Exp(phi_k)`
  - `R_{k+1} = R_k Exp(dt * omega_k)`
  - `phi_{k+1} = Log(R_{k+1})`
- Kept rigid-body torque dynamics unchanged for angular velocity:
  - `omega_dot = I^{-1}(tau - omega x (I omega))`

## Code changes
### `spacecraft_libraries/dynamics.py`
- Added CasADi-compatible SO(3) helpers:
  - `hat_casadi(v)`
  - `vee_casadi(S)`
  - `so3_exp_casadi(phi)` (Rodrigues + small-angle series)
  - `so3_log_casadi(R)` (trace/acos with clamping + small-angle branch)
- Added `rotational_step_casadi(state, tau, dt, I)` to propagate `[phi, omega]` on SO(3).
- Refactored `rotational_derivative_casadi` to match the 6D state (`[phi, omega]`) as a local-coordinate fallback derivative.

### `spacecraft_libraries/genetic_code.py`
- Updated both `multiple_shooting_optimization` and `multiple_shooting_optimization_new` to use 6D states throughout:
  - state symbol sizes
  - constraint dimensions
  - state bounds and reshape logic
  - initial/final constraint vectors
- Replaced dynamics continuity step with `rotational_step_casadi(...)`.
- Removed quaternion normalization from multiple-shooting propagation.
- Kept quadratic control effort objective and decision-variable structure unchanged.
- Added `_quaternion_to_phi(...)` to allow boundary attitude input as either phi(3) or legacy quaternion(4) when using `BoundaryConditions`.

## Notes / caveats
- `Log(R)` on SO(3) is numerically sensitive near rotation angle `pi`; this patch includes clamping and branching for robustness, but ambiguity of axis sign and branch-cut behavior near `pi` remain inherent.
- Small-angle handling is included in both Exp/Log for better conditioning around zero rotation.

## Validation
- Performed syntax validation with:
  - `python -m py_compile spacecraft_libraries/dynamics.py spacecraft_libraries/genetic_code.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19f0a61c4832d88ccdffe89d8c880)