### PR TITLE
Add scenario switching and progress bar to compare_methods

### DIFF
--- a/scripts/compare_methods.py
+++ b/scripts/compare_methods.py
@@ -1,14 +1,38 @@
 from pathlib import Path
+import argparse
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from spacecraft_libraries.evaluation import default_scenario, run_method_comparison
+from spacecraft_libraries.evaluation import get_scenario, run_method_comparison
+
+
+def _print_progress(current: int, total: int, method_name: str, width: int = 30) -> None:
+    filled = int(width * current / total) if total else width
+    bar = "#" * filled + "-" * (width - filled)
+    percent = int(100 * current / total) if total else 100
+    print(f"\r[{bar}] {percent:3d}% ({current}/{total}) {method_name}", end="", flush=True)
+    if current == total:
+        print()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare optimization methods across predefined scenarios.")
+    parser.add_argument(
+        "--scenario",
+        type=int,
+        default=1,
+        choices=(1, 2, 3),
+        help="Scenario number to run (1, 2, or 3).",
+    )
+    return parser.parse_args()
 
 
 def main():
-    sys_params, bc, epsilon = default_scenario()
-    rows = run_method_comparison(sys_params, bc, epsilon)
+    args = parse_args()
+    sys_params, bc, epsilon = get_scenario(args.scenario)
+    print(f"Running method comparison for scenario {args.scenario}")
+    rows = run_method_comparison(sys_params, bc, epsilon, progress_callback=_print_progress)
     print("method,cost,terminal_violation,runtime_s")
     for row in rows:
         print(f"{row['method']},{row['cost']:.6f},{row['terminal_violation']:.6f},{row['runtime_s']:.3f}")

--- a/spacecraft_libraries/__init__.py
+++ b/spacecraft_libraries/__init__.py
@@ -87,6 +87,10 @@ _EXPORTS: Dict[str, Tuple[str, str]] = {
     "solve_decentralized_island_ga": ("solvers.decentralized_island_ga", "solve_decentralized_island_ga"),
     # evaluation
     "default_scenario": ("evaluation.comparison", "default_scenario"),
+    "get_scenario": ("evaluation.comparison", "get_scenario"),
+    "scenario_1": ("evaluation.comparison", "scenario_1"),
+    "scenario_2": ("evaluation.comparison", "scenario_2"),
+    "scenario_3": ("evaluation.comparison", "scenario_3"),
     "run_method_comparison": ("evaluation.comparison", "run_method_comparison"),
     # module export
     "animator": ("animator", None),

--- a/spacecraft_libraries/evaluation/__init__.py
+++ b/spacecraft_libraries/evaluation/__init__.py
@@ -1,3 +1,3 @@
-from .comparison import default_scenario, run_method_comparison
+from .comparison import default_scenario, get_scenario, run_method_comparison, scenario_1, scenario_2, scenario_3
 
-__all__ = ["default_scenario", "run_method_comparison"]
+__all__ = ["default_scenario", "get_scenario", "scenario_1", "scenario_2", "scenario_3", "run_method_comparison"]

--- a/spacecraft_libraries/evaluation/comparison.py
+++ b/spacecraft_libraries/evaluation/comparison.py
@@ -7,7 +7,7 @@ from ..solvers import solve_centralized_ga, solve_centralized_nlp, solve_decentr
 from .metrics import quaternion_aware_violation, terminal_violation
 
 
-def default_scenario() -> tuple[SystemParams, BoundaryConditions, float]:
+def scenario_1() -> tuple[SystemParams, BoundaryConditions, float]:
     rs = [np.array([0.5, 1.0, 1.5]), np.array([0.0, 0.5, 2.0]), np.array([-0.5, 1.0, -1.5])]
     sys_params = SystemParams(
         mu=3.98e14,
@@ -27,6 +27,57 @@ def default_scenario() -> tuple[SystemParams, BoundaryConditions, float]:
     return sys_params, bc, 1e-5
 
 
+def scenario_2() -> tuple[SystemParams, BoundaryConditions, float]:
+    rs = [np.array([1.0, -0.5, 1.0]), np.array([-1.0, 0.75, 1.5]), np.array([0.25, 1.2, -1.25])]
+    sys_params = SystemParams(
+        mu=3.98e14,
+        a=8e6,
+        e=0.35,
+        nu=np.pi / 3,
+        I=800 * np.diag([1.0, 1.5, 2.5]),
+        m=120,
+        rs=rs,
+        N=25,
+    )
+    bc = BoundaryConditions(
+        x0=StateVector(r=np.array([0, 0, 0]), v=np.array([0, 0, 0]), eps=np.array([0, 0, 0, 1]), omega=np.array([0, 0, 0])),
+        xf=StateVector(r=np.array([7, 4, 6]), v=np.array([0, 0, 0]), eps=np.array([0.0, 0.707, 0.0, 0.707]), omega=np.array([0, 0, 0])),
+        tf=60,
+    )
+    return sys_params, bc, 1e-4
+
+
+def scenario_3() -> tuple[SystemParams, BoundaryConditions, float]:
+    rs = [np.array([-0.75, 1.5, 0.5]), np.array([0.5, -1.0, 2.2]), np.array([1.0, 0.75, -1.8])]
+    sys_params = SystemParams(
+        mu=3.98e14,
+        a=8.5e6,
+        e=0.1,
+        nu=np.pi / 6,
+        I=1200 * np.diag([0.8, 1.4, 2.0]),
+        m=90,
+        rs=rs,
+        N=30,
+    )
+    bc = BoundaryConditions(
+        x0=StateVector(r=np.array([0, 0, 0]), v=np.array([0, 0, 0]), eps=np.array([0, 0, 0, 1]), omega=np.array([0, 0, 0])),
+        xf=StateVector(r=np.array([4, 6, 3]), v=np.array([0, 0, 0]), eps=np.array([0.5, -0.5, 0.5, 0.5]), omega=np.array([0, 0, 0])),
+        tf=45,
+    )
+    return sys_params, bc, 5e-5
+
+
+def get_scenario(scenario_id: int) -> tuple[SystemParams, BoundaryConditions, float]:
+    scenarios = {1: scenario_1, 2: scenario_2, 3: scenario_3}
+    if scenario_id not in scenarios:
+        raise ValueError(f"Unknown scenario '{scenario_id}'. Valid options are: 1, 2, 3.")
+    return scenarios[scenario_id]()
+
+
+def default_scenario() -> tuple[SystemParams, BoundaryConditions, float]:
+    return scenario_1()
+
+
 def _extract_terminal_state(result, method: str):
     if method == "centralized_nlp":
         x = result["state"]
@@ -36,12 +87,21 @@ def _extract_terminal_state(result, method: str):
     return {"r": s.r, "v": s.v, "eps": s.eps, "omega": s.omega}
 
 
-def run_method_comparison(sys_params: SystemParams, bc: BoundaryConditions, epsilon: float):
-    results = [
-        solve_centralized_nlp(sys_params, bc, max_iters=30),
-        solve_centralized_ga(sys_params, bc, epsilon, pop_size=8, generations=5),
-        solve_decentralized_island_ga(sys_params, bc, epsilon, pop_size=8, migration_rounds=3),
+def run_method_comparison(sys_params: SystemParams, bc: BoundaryConditions, epsilon: float, progress_callback=None):
+    methods = [
+        ("centralized_nlp", lambda: solve_centralized_nlp(sys_params, bc, max_iters=30)),
+        ("centralized_ga", lambda: solve_centralized_ga(sys_params, bc, epsilon, pop_size=8, generations=5)),
+        ("decentralized_island_ga", lambda: solve_decentralized_island_ga(sys_params, bc, epsilon, pop_size=8, migration_rounds=3)),
     ]
+
+    results = []
+    total_methods = len(methods)
+    for index, (method_name, solver) in enumerate(methods, start=1):
+        if progress_callback is not None:
+            progress_callback(index - 1, total_methods, method_name)
+        results.append(solver())
+        if progress_callback is not None:
+            progress_callback(index, total_methods, method_name)
 
     table = []
     for result in results:


### PR DESCRIPTION
## Summary
- Added three predefined comparison scenarios in `spacecraft_libraries.evaluation.comparison` and a `get_scenario(scenario_id)` selector.
- Kept `default_scenario()` behavior by mapping it to scenario 1.
- Updated `run_method_comparison(...)` to support an optional `progress_callback` invoked before/after each solver runs.
- Enhanced `scripts/compare_methods.py` with:
  - `--scenario {1,2,3}` CLI argument
  - a simple terminal progress bar during solver execution
  - scenario-specific run banner output
- Exported new scenario helpers via `spacecraft_libraries.evaluation` and top-level `spacecraft_libraries` lazy exports.

## Validation
- Attempted to run `python scripts/compare_methods.py --help` but local environment is missing `numpy`, so runtime validation could not complete.

## Notes
- No solver logic changes were made beyond adding progress callback plumbing and scenario selection support.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1dd055380832da6e2be82ddb36e3a)