### PR TITLE
Add configurable runtime cap support to comparison drivers and solvers

### DIFF
--- a/scripts/run_comparison.py
+++ b/scripts/run_comparison.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from spacecraft_libraries.evaluation import default_scenario, run_method_comparison
+
+# Set to None to disable runtime caps.
+TOTAL_RUNTIME_CAP_S = 30.0
+
+
+def main():
+    sys_params, bc, epsilon = default_scenario()
+    rows = run_method_comparison(sys_params, bc, epsilon, max_runtime_s=TOTAL_RUNTIME_CAP_S)
+    print("method,cost,terminal_violation,runtime_s")
+    for row in rows:
+        print(f"{row['method']},{row['cost']:.6f},{row['terminal_violation']:.6f},{row['runtime_s']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/spacecraft_libraries/evaluation/comparison.py
+++ b/spacecraft_libraries/evaluation/comparison.py
@@ -36,11 +36,23 @@ def _extract_terminal_state(result, method: str):
     return {"r": s.r, "v": s.v, "eps": s.eps, "omega": s.omega}
 
 
-def run_method_comparison(sys_params: SystemParams, bc: BoundaryConditions, epsilon: float):
+def run_method_comparison(
+    sys_params: SystemParams,
+    bc: BoundaryConditions,
+    epsilon: float,
+    max_runtime_s: float | None = None,
+):
     results = [
-        solve_centralized_nlp(sys_params, bc, max_iters=30),
-        solve_centralized_ga(sys_params, bc, epsilon, pop_size=8, generations=5),
-        solve_decentralized_island_ga(sys_params, bc, epsilon, pop_size=8, migration_rounds=3),
+        solve_centralized_nlp(sys_params, bc, max_iters=30, max_runtime_s=max_runtime_s),
+        solve_centralized_ga(sys_params, bc, epsilon, pop_size=8, generations=5, max_runtime_s=max_runtime_s),
+        solve_decentralized_island_ga(
+            sys_params,
+            bc,
+            epsilon,
+            pop_size=8,
+            migration_rounds=3,
+            max_runtime_s=max_runtime_s,
+        ),
     ]
 
     table = []

--- a/spacecraft_libraries/graph/graph_manager.py
+++ b/spacecraft_libraries/graph/graph_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import time
 
 import networkx as nx
 import numpy as np
@@ -34,10 +35,16 @@ class GraphManager:
             neighbors = np.where((distances[i] < self.line_of_sight_limit) & (distances[i] > 0))[0]
             self.graph.add_edges_from((i, int(j)) for j in neighbors)
 
-    def run_island_evolution(self, pop_size: int) -> None:
+    def run_island_evolution(self, pop_size: int, max_runtime_s: float | None = None) -> None:
         for agent in self.agents:
             agent.initialise_island(pop_size)
+
+        start = time.perf_counter()
+        effective_limit = None if max_runtime_s is None else max_runtime_s * self.num_agents
+
         for _ in range(self.migration_rounds):
+            if effective_limit is not None and (time.perf_counter() - start) >= effective_limit:
+                break
             for agent in self.agents:
                 agent.step_generation()
             self._communicate_best()

--- a/spacecraft_libraries/og_opts.py
+++ b/spacecraft_libraries/og_opts.py
@@ -304,7 +304,7 @@ def seq_conv_opt(x0, xf, tf, x_hist, mu, a, e, nu, I, m, rs, bc: BoundaryConditi
 
     return r.value, v.value, epsilon.value, omega.value, qs.value, [U[i].value for i in range(6)], tau.value
 
-def full_nlp(x0, xf, tf, mu, a, e, nu, I, m, rs, N, max_iters=100):
+def full_nlp(x0, xf, tf, mu, a, e, nu, I, m, rs, N, max_iters=100, max_runtime_s=None):
     num_steps = N  # Assuming N is defined
     num_agents = len(rs)
     dt = tf / num_steps
@@ -446,8 +446,21 @@ def full_nlp(x0, xf, tf, mu, a, e, nu, I, m, rs, N, max_iters=100):
     # Solve the optimization problem
     #result = minimize(objective, U0_flat, method='SLSQP', constraints=[cons, cons_ineq],
     #                  options={'maxiter': max_iters, 'verbosity': 2})
-    result = minimize(objective, U0_flat, method='trust-constr', constraints=[eq_constraint],
-                      options={'maxiter': max_iters, 'verbose': 2})
+    opt_start = time.perf_counter()
+
+    def stop_on_timeout(_, __):
+        if max_runtime_s is None:
+            return False
+        return (time.perf_counter() - opt_start) >= max_runtime_s
+
+    result = minimize(
+        objective,
+        U0_flat,
+        method='trust-constr',
+        constraints=[eq_constraint],
+        options={'maxiter': max_iters, 'verbose': 2},
+        callback=stop_on_timeout,
+    )
     U_opt = result.x.reshape((num_agents, num_steps, 3))
 
     r_fin = np.zeros((num_steps+1,3))

--- a/spacecraft_libraries/solvers/centralized_ga.py
+++ b/spacecraft_libraries/solvers/centralized_ga.py
@@ -15,6 +15,7 @@ def solve_centralized_ga(
     epsilon: float,
     pop_size: int = 20,
     generations: int = 10,
+    max_runtime_s: float | None = None,
 ):
     def fitness_wrapper(ga_instance, solution, solution_idx):
         return genetic_code.fitness_func(
@@ -31,7 +32,7 @@ def solve_centralized_ga(
     init_pop = [candidate.flatten() for candidate in init_pop]
 
     ga = pygad.GA(
-        num_generations=generations,
+        num_generations=1,
         num_parents_mating=max(2, pop_size // 2),
         initial_population=init_pop,
         fitness_func=fitness_wrapper,
@@ -46,7 +47,13 @@ def solve_centralized_ga(
     )
 
     start = time.perf_counter()
-    ga.run()
+    generations_completed = 0
+    while generations_completed < generations:
+        ga.run()
+        generations_completed += 1
+        ga.initial_population = np.array(ga.population, copy=True)
+        if max_runtime_s is not None and (time.perf_counter() - start) >= max_runtime_s:
+            break
     runtime = time.perf_counter() - start
 
     best_solution, _, _ = ga.best_solution()

--- a/spacecraft_libraries/solvers/centralized_nlp.py
+++ b/spacecraft_libraries/solvers/centralized_nlp.py
@@ -8,7 +8,12 @@ from .. import og_opts
 from ..data_structures import BoundaryConditions, SystemParams
 
 
-def solve_centralized_nlp(sys_params: SystemParams, bc: BoundaryConditions, max_iters: int = 100):
+def solve_centralized_nlp(
+    sys_params: SystemParams,
+    bc: BoundaryConditions,
+    max_iters: int = 100,
+    max_runtime_s: float | None = None,
+):
     start = time.perf_counter()
     U, X, Q = og_opts.full_nlp(
         x0=bc.x0.as_array(),
@@ -23,6 +28,7 @@ def solve_centralized_nlp(sys_params: SystemParams, bc: BoundaryConditions, max_
         rs=sys_params.rs,
         N=sys_params.N,
         max_iters=max_iters,
+        max_runtime_s=max_runtime_s,
     )
     runtime = time.perf_counter() - start
     return {

--- a/spacecraft_libraries/solvers/decentralized_island_ga.py
+++ b/spacecraft_libraries/solvers/decentralized_island_ga.py
@@ -14,6 +14,7 @@ def solve_decentralized_island_ga(
     epsilon: float,
     pop_size: int = 10,
     migration_rounds: int = 5,
+    max_runtime_s: float | None = None,
 ):
     manager = GraphManager(
         attach_vecs=np.array(sys_params.rs),
@@ -24,7 +25,7 @@ def solve_decentralized_island_ga(
     )
     manager.build_line_of_sight_graph()
     start = time.perf_counter()
-    manager.run_island_evolution(pop_size=pop_size)
+    manager.run_island_evolution(pop_size=pop_size, max_runtime_s=max_runtime_s)
     result = manager.run_consensus()
     runtime = time.perf_counter() - start
     result.update({"method": "decentralized_island_ga", "runtime": runtime})


### PR DESCRIPTION
### Motivation
- Provide a single, easily-configurable total runtime cap for method comparisons so each solver can be limited consistently during evaluations.
- Implement different timeout behaviors per solver: stop IPOPT/full NLP via a callback, stop spawning GA generations when time elapses, and for the decentralized island GA convert remaining migration budget into a time-limited migration phase that transitions to consensus when expired.

### Description
- Added `scripts/run_comparison.py` with a `TOTAL_RUNTIME_CAP_S` constant and wired it into `run_method_comparison` via a new `max_runtime_s` parameter.
- Extended `run_method_comparison` to accept `max_runtime_s` and pass it to all three solvers (`centralized_nlp`, `centralized_ga`, `decentralized_island_ga`).
- Plumbed `max_runtime_s` into `og_opts.full_nlp` and added a wall-clock timeout callback to stop the `trust-constr` solver when the runtime cap is reached (`spacecraft_libraries/og_opts.py` and `spacecraft_libraries/solvers/centralized_nlp.py`).
- Modified centralized GA to run one generation at a time and check elapsed wall time between generations to stop early (`spacecraft_libraries/solvers/centralized_ga.py`).
- Updated decentralized island GA and `GraphManager.run_island_evolution` to accept `max_runtime_s`, scale the effective migration time by `num_agents` (parallelism), stop migration when the cap is hit, and then proceed to the consensus phase (`spacecraft_libraries/solvers/decentralized_island_ga.py` and `spacecraft_libraries/graph/graph_manager.py`).

### Testing
- Compiled all modified modules with `python -m compileall scripts/run_comparison.py spacecraft_libraries/evaluation/comparison.py spacecraft_libraries/solvers/centralized_nlp.py spacecraft_libraries/solvers/centralized_ga.py spacecraft_libraries/solvers/decentralized_island_ga.py spacecraft_libraries/graph/graph_manager.py spacecraft_libraries/og_opts.py`, which succeeded.
- Performed a quick smoke attempt calling `run_method_comparison(..., max_runtime_s=0.01)`, which could not complete due to missing runtime dependencies in the environment (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1decca504832db46594f0a3d9a2fc)