### PR TITLE
Add solver comparison script, runtime caps, silent/progress modes, and timeout support in solvers

### DIFF
--- a/scripts/run_comparison.py
+++ b/scripts/run_comparison.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from spacecraft_libraries.evaluation import default_scenario, run_method_comparison
+
+# Set to None to disable runtime caps.
+TOTAL_RUNTIME_CAP_S = 30.0
+
+
+def main():
+    sys_params, bc, epsilon = default_scenario()
+    rows = run_method_comparison(
+        sys_params,
+        bc,
+        epsilon,
+        max_runtime_s=TOTAL_RUNTIME_CAP_S,
+        show_progress=True,
+    )
+    print("method,cost,terminal_violation,runtime_s")
+    for row in rows:
+        print(f"{row['method']},{row['cost']:.6f},{row['terminal_violation']:.6f},{row['runtime_s']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/spacecraft_libraries/evaluation/comparison.py
+++ b/spacecraft_libraries/evaluation/comparison.py
@@ -1,10 +1,33 @@
 from __future__ import annotations
 
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from pathlib import Path
+
 import numpy as np
 
 from ..data_structures import BoundaryConditions, StateVector, SystemParams
 from ..solvers import solve_centralized_ga, solve_centralized_nlp, solve_decentralized_island_ga
 from .metrics import quaternion_aware_violation, terminal_violation
+
+
+@contextmanager
+def _suppress_solver_output(enabled: bool):
+    if not enabled:
+        yield
+        return
+    devnull_path = Path("/dev/null")
+    with devnull_path.open("w") as devnull:
+        with redirect_stdout(devnull), redirect_stderr(devnull):
+            yield
+
+
+def _render_loading_bar(completed: int, total: int) -> None:
+    width = 30
+    filled = int(width * completed / total)
+    bar = "#" * filled + "-" * (width - filled)
+    print(f"\rRunning solvers [{bar}] {completed}/{total}", end="", flush=True)
+    if completed == total:
+        print()
 
 
 def default_scenario() -> tuple[SystemParams, BoundaryConditions, float]:
@@ -36,12 +59,37 @@ def _extract_terminal_state(result, method: str):
     return {"r": s.r, "v": s.v, "eps": s.eps, "omega": s.omega}
 
 
-def run_method_comparison(sys_params: SystemParams, bc: BoundaryConditions, epsilon: float):
-    results = [
-        solve_centralized_nlp(sys_params, bc, max_iters=30),
-        solve_centralized_ga(sys_params, bc, epsilon, pop_size=8, generations=5),
-        solve_decentralized_island_ga(sys_params, bc, epsilon, pop_size=8, migration_rounds=3),
+def run_method_comparison(
+    sys_params: SystemParams,
+    bc: BoundaryConditions,
+    epsilon: float,
+    max_runtime_s: float | None = None,
+    show_progress: bool = False,
+    silence_solver_output: bool = True,
+):
+    solver_calls = [
+        lambda: solve_centralized_nlp(sys_params, bc, max_iters=30, max_runtime_s=max_runtime_s),
+        lambda: solve_centralized_ga(sys_params, bc, epsilon, pop_size=8, generations=5, max_runtime_s=max_runtime_s),
+        lambda: solve_decentralized_island_ga(
+            sys_params,
+            bc,
+            epsilon,
+            pop_size=8,
+            migration_rounds=3,
+            max_runtime_s=max_runtime_s,
+        ),
     ]
+
+    results = []
+    total = len(solver_calls)
+    if show_progress:
+        _render_loading_bar(0, total)
+
+    for idx, solver in enumerate(solver_calls, start=1):
+        with _suppress_solver_output(silence_solver_output):
+            results.append(solver())
+        if show_progress:
+            _render_loading_bar(idx, total)
 
     table = []
     for result in results:

--- a/spacecraft_libraries/genetic_code.py
+++ b/spacecraft_libraries/genetic_code.py
@@ -293,7 +293,6 @@ def pop_gen_new(bc:BoundaryConditions, sys_params:SystemParams,  N, epsilon,pop_
 def fitness_func(ga_instance,N,epsilon, sys_params: SystemParams, bc: BoundaryConditions, solution, solution_idx):
     # Reshape the solution into the correct tau format (num_steps x 3)
     tau = solution.reshape((N, 3))
-    print("Using Nonlinear Torque Projection")
     tau = tau_proj_nonlin_new(tau, N, epsilon, sys_params, bc)[0]
     #NOTE: 3000 kept
     traj, _,_, cost = opt_given_tau_ipopt_new(tau,N, epsilon, sys_params, bc, num_iter=3000) #outputs of this function are traj_opt, ctrl_opt, Q_opt, and min cost
@@ -305,7 +304,6 @@ def fitness_func(ga_instance,N,epsilon, sys_params: SystemParams, bc: BoundaryCo
     #fitness = 1 / (cost + (alpha*float(np.linalg.norm(fin_ang_state-expected_final_ang_state))**2))
     fitness = 1 / (cost)
 
-    print("Current Cost: " + str(cost))
     if fitness == np.inf:
       fitness = 0
     return fitness

--- a/spacecraft_libraries/graph/graph_manager.py
+++ b/spacecraft_libraries/graph/graph_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import time
 
 import networkx as nx
 import numpy as np
@@ -34,10 +35,16 @@ class GraphManager:
             neighbors = np.where((distances[i] < self.line_of_sight_limit) & (distances[i] > 0))[0]
             self.graph.add_edges_from((i, int(j)) for j in neighbors)
 
-    def run_island_evolution(self, pop_size: int) -> None:
+    def run_island_evolution(self, pop_size: int, max_runtime_s: float | None = None) -> None:
         for agent in self.agents:
             agent.initialise_island(pop_size)
+
+        start = time.perf_counter()
+        effective_limit = None if max_runtime_s is None else max_runtime_s * self.num_agents
+
         for _ in range(self.migration_rounds):
+            if effective_limit is not None and (time.perf_counter() - start) >= effective_limit:
+                break
             for agent in self.agents:
                 agent.step_generation()
             self._communicate_best()

--- a/spacecraft_libraries/og_opts.py
+++ b/spacecraft_libraries/og_opts.py
@@ -304,7 +304,7 @@ def seq_conv_opt(x0, xf, tf, x_hist, mu, a, e, nu, I, m, rs, bc: BoundaryConditi
 
     return r.value, v.value, epsilon.value, omega.value, qs.value, [U[i].value for i in range(6)], tau.value
 
-def full_nlp(x0, xf, tf, mu, a, e, nu, I, m, rs, N, max_iters=100):
+def full_nlp(x0, xf, tf, mu, a, e, nu, I, m, rs, N, max_iters=100, max_runtime_s=None):
     num_steps = N  # Assuming N is defined
     num_agents = len(rs)
     dt = tf / num_steps
@@ -446,8 +446,21 @@ def full_nlp(x0, xf, tf, mu, a, e, nu, I, m, rs, N, max_iters=100):
     # Solve the optimization problem
     #result = minimize(objective, U0_flat, method='SLSQP', constraints=[cons, cons_ineq],
     #                  options={'maxiter': max_iters, 'verbosity': 2})
-    result = minimize(objective, U0_flat, method='trust-constr', constraints=[eq_constraint],
-                      options={'maxiter': max_iters, 'verbose': 2})
+    opt_start = time.perf_counter()
+
+    def stop_on_timeout(_, __):
+        if max_runtime_s is None:
+            return False
+        return (time.perf_counter() - opt_start) >= max_runtime_s
+
+    result = minimize(
+        objective,
+        U0_flat,
+        method='trust-constr',
+        constraints=[eq_constraint],
+        options={'maxiter': max_iters, 'verbose': 0},
+        callback=stop_on_timeout,
+    )
     U_opt = result.x.reshape((num_agents, num_steps, 3))
 
     r_fin = np.zeros((num_steps+1,3))

--- a/spacecraft_libraries/solvers/centralized_ga.py
+++ b/spacecraft_libraries/solvers/centralized_ga.py
@@ -15,6 +15,7 @@ def solve_centralized_ga(
     epsilon: float,
     pop_size: int = 20,
     generations: int = 10,
+    max_runtime_s: float | None = None,
 ):
     def fitness_wrapper(ga_instance, solution, solution_idx):
         return genetic_code.fitness_func(
@@ -31,7 +32,7 @@ def solve_centralized_ga(
     init_pop = [candidate.flatten() for candidate in init_pop]
 
     ga = pygad.GA(
-        num_generations=generations,
+        num_generations=1,
         num_parents_mating=max(2, pop_size // 2),
         initial_population=init_pop,
         fitness_func=fitness_wrapper,
@@ -46,7 +47,13 @@ def solve_centralized_ga(
     )
 
     start = time.perf_counter()
-    ga.run()
+    generations_completed = 0
+    while generations_completed < generations:
+        ga.run()
+        generations_completed += 1
+        ga.initial_population = np.array(ga.population, copy=True)
+        if max_runtime_s is not None and (time.perf_counter() - start) >= max_runtime_s:
+            break
     runtime = time.perf_counter() - start
 
     best_solution, _, _ = ga.best_solution()

--- a/spacecraft_libraries/solvers/centralized_nlp.py
+++ b/spacecraft_libraries/solvers/centralized_nlp.py
@@ -8,7 +8,12 @@ from .. import og_opts
 from ..data_structures import BoundaryConditions, SystemParams
 
 
-def solve_centralized_nlp(sys_params: SystemParams, bc: BoundaryConditions, max_iters: int = 100):
+def solve_centralized_nlp(
+    sys_params: SystemParams,
+    bc: BoundaryConditions,
+    max_iters: int = 100,
+    max_runtime_s: float | None = None,
+):
     start = time.perf_counter()
     U, X, Q = og_opts.full_nlp(
         x0=bc.x0.as_array(),
@@ -23,6 +28,7 @@ def solve_centralized_nlp(sys_params: SystemParams, bc: BoundaryConditions, max_
         rs=sys_params.rs,
         N=sys_params.N,
         max_iters=max_iters,
+        max_runtime_s=max_runtime_s,
     )
     runtime = time.perf_counter() - start
     return {

--- a/spacecraft_libraries/solvers/decentralized_island_ga.py
+++ b/spacecraft_libraries/solvers/decentralized_island_ga.py
@@ -14,6 +14,7 @@ def solve_decentralized_island_ga(
     epsilon: float,
     pop_size: int = 10,
     migration_rounds: int = 5,
+    max_runtime_s: float | None = None,
 ):
     manager = GraphManager(
         attach_vecs=np.array(sys_params.rs),
@@ -24,7 +25,7 @@ def solve_decentralized_island_ga(
     )
     manager.build_line_of_sight_graph()
     start = time.perf_counter()
-    manager.run_island_evolution(pop_size=pop_size)
+    manager.run_island_evolution(pop_size=pop_size, max_runtime_s=max_runtime_s)
     result = manager.run_consensus()
     runtime = time.perf_counter() - start
     result.update({"method": "decentralized_island_ga", "runtime": runtime})


### PR DESCRIPTION
### Motivation
- Provide a small CLI to compare solver methods and collect metrics in a CSV-like output. 
- Allow experiments to cap solver runtimes to keep end-to-end comparisons bounded. 
- Allow suppressing noisy solver output and display a simple progress bar for user feedback. 

### Description
- Add `scripts/run_comparison.py` which calls `default_scenario()` and `run_method_comparison()` and prints a CSV header plus rows for each method. 
- Extend `spacecraft_libraries/evaluation/comparison.py` with `_suppress_solver_output`, `_render_loading_bar`, and a new `run_method_comparison()` signature that supports `max_runtime_s`, `show_progress`, and `silence_solver_output`. 
- Propagate timeout support into solvers and optimizers by adding `max_runtime_s` parameters and early-stop logic in `full_nlp`, `solve_centralized_nlp`, `solve_centralized_ga`, `solve_decentralized_island_ga`, and `GraphManager.run_island_evolution`, and also added a global-aware timeout for island evolution. 
- Improve GA loop to run multiple generations incrementally so it can check the runtime cap between generation batches and re-seed the population for continuation. 
- Remove stray debug `print` statements in `genetic_code.fitness_func` and adjust solver output handling so solver libraries can be silenced when desired. 

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1decca504832db46594f0a3d9a2fc)